### PR TITLE
Fix CSS properties

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -13,26 +13,26 @@ span.text {
   padding: 2px;
 }
 
-div .selected {
-  border: 'yellow';
-  border_width: 1;
-  border_style: 'solid';
+div.selected {
+  border-color: yellow;
+  border-width: 1;
+  border-style: 'solid';
 }
 
-div .editable {
-  background: 'white';
+div.editable {
+  background: white;
 }
 
-button .selected {
-  border: 'gold';
-  border_width: 2;
-  border_style: 'solid';
+button.selected {
+  border-color: gold;
+  border-width: 2;
+  border-style: solid;
 }
 
-button .selected .uneditable {
-  border: 'grey';
-  border_width: 2;
-  border_style: 'dot';
+button.selected.uneditable {
+  border-color: grey;
+  border-width: 2;
+  border-style: dot;
 }
 
 text {


### PR DESCRIPTION
Important things to remember about CSS
- Space between selectors means you are selecting children, no space means you are adding specificity to your selection
  
  `button .selected` means "something with `class="selected"` that has a `<button>` as it's parent"
  
  `button.selected` means "A `<button>` with `class="selected"`"
- CSS properties use dashes in their names. In javascript libraries, we generally refer to these attributes using underscores since dashes are subtraction operators in javascript

Fix #72 
