### PR TITLE
allow real JSON strings to be passed as custom

### DIFF
--- a/src/load.coffee
+++ b/src/load.coffee
@@ -62,8 +62,9 @@ get_custom_level = ->
   return unless custom?
 
   try
-    custom = atob custom
-    JSON.parse custom
+    custom = decodeURIComponent custom
+    custom = JSON.parse custom
+    custom
   catch
     console.error 'unable to read custom JSON'
     null


### PR DESCRIPTION
Try this (on local)

[Custom Level](http://localhost:3000/?game=tutorial&level=3&custom={%22name%22:%22My%20Custom%20Level%22,%22sprites%22:[{},{%22fill%22:%22purple%22,%22actions%22:{%22run%22:[%22right%22,%22forward%22,%22left%22,%22forward%22,%22left%22]}},{%22kind%22:%22log%22,%22position%22:[1,0]}],%22goal%22:{%22clicks%22:4}})
